### PR TITLE
Add Lorenz forecasting test script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch
+numpy
 adam-atan2
 einops
 tqdm

--- a/tests/test_lorenz_forecast.py
+++ b/tests/test_lorenz_forecast.py
@@ -1,0 +1,66 @@
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from dataset.time_series_dataset import TimeSeriesWindows
+from models.ts_hrm_adapter import TimeSeriesHRM, ts_train_step
+
+
+def lorenz_series(T: int = 1000, dt: float = 0.01,
+                  sigma: float = 10.0, rho: float = 28.0,
+                  beta: float = 8/3) -> np.ndarray:
+    """Generate a Lorenz attractor time series of length ``T``.
+
+    Parameters
+    ----------
+    T: int
+        Number of timesteps to simulate.
+    dt: float
+        Integration step size.
+    sigma, rho, beta: float
+        Standard Lorenz system parameters.
+    """
+    xyz = np.zeros((T, 3), dtype=np.float32)
+    xyz[0] = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+    for t in range(1, T):
+        x, y, z = xyz[t - 1]
+        x_dot = sigma * (y - x)
+        y_dot = x * (rho - z) - y
+        z_dot = x * y - beta * z
+        xyz[t] = xyz[t - 1] + dt * np.array([x_dot, y_dot, z_dot], dtype=np.float32)
+    return xyz
+
+
+class GRUCore(nn.Module):
+    """Minimal recurrent core to plug into :class:`TimeSeriesHRM`."""
+
+    def __init__(self, d_model: int) -> None:
+        super().__init__()
+        self.rnn = nn.GRU(d_model, d_model, batch_first=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        out, _ = self.rnn(x)
+        return out
+
+
+def main() -> None:
+    series = lorenz_series()
+    dataset = TimeSeriesWindows(series, series, T_in=20, T_out=1)
+    loader = DataLoader(dataset, batch_size=32, shuffle=True)
+
+    d_in = series.shape[1]
+    d_model = 64
+    d_out = d_in
+    model = TimeSeriesHRM(GRUCore(d_model), d_in=d_in, d_model=d_model, d_out=d_out)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    batch = next(iter(loader))
+    loss = ts_train_step(model, batch)
+    loss.backward()
+    opt.step()
+    print(f"Loss after one training step: {loss.item():.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add Lorenz attractor forecasting example using TimeSeriesHRM and a GRU core
- include numpy in dependencies

## Testing
- `pip install numpy` (fails: Tunnel connection failed: 403 Forbidden)
- `python tests/test_lorenz_forecast.py` (fails: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_689fba1524cc8333968ea07cc2e35d3a