### PR TITLE
Add hierarchical core for time-series adapter

### DIFF
--- a/TIME_SERIES_ADAPTATION.md
+++ b/TIME_SERIES_ADAPTATION.md
@@ -27,4 +27,10 @@ This repository has been extended to handle time series forecasting tasks. The m
   - Embeds inputs, forwards them through the HRM, and applies the regression head.
   - Includes a helper `ts_train_step` that performs a forward pass and returns the appropriate loss.
 
+## `models/ts_hierarchical_core.py`
+* **Purpose:** Offer an HRM-inspired core for continuous embeddings.
+* **Key Features:**
+  - Implements the hierarchical H/L block cycles with rotary attention.
+  - Produces transformed sequences compatible with `TimeSeriesHRM`.
+
 These components together allow the HRM architecture to model temporal dynamics, capturing both short-term variations and long-range trends within sequential data.

--- a/models/ts_hierarchical_core.py
+++ b/models/ts_hierarchical_core.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+from typing import List
+
+import torch
+import torch.nn as nn
+
+from .layers import rms_norm, SwiGLU, Attention, RotaryEmbedding
+
+
+class HRMBlock(nn.Module):
+    """Single transformer block used within the hierarchical core."""
+
+    def __init__(self, d_model: int, num_heads: int, expansion: float = 4.0, rms_norm_eps: float = 1e-5) -> None:
+        super().__init__()
+        head_dim = d_model // num_heads
+        self.self_attn = Attention(
+            hidden_size=d_model,
+            head_dim=head_dim,
+            num_heads=num_heads,
+            num_key_value_heads=num_heads,
+            causal=False,
+        )
+        self.mlp = SwiGLU(hidden_size=d_model, expansion=expansion)
+        self.norm_eps = rms_norm_eps
+
+    def forward(self, cos_sin, hidden_states: torch.Tensor) -> torch.Tensor:
+        hidden_states = rms_norm(
+            hidden_states + self.self_attn(cos_sin=cos_sin, hidden_states=hidden_states),
+            variance_epsilon=self.norm_eps,
+        )
+        hidden_states = rms_norm(
+            hidden_states + self.mlp(hidden_states),
+            variance_epsilon=self.norm_eps,
+        )
+        return hidden_states
+
+
+class HRMReasoningModule(nn.Module):
+    """Repeatedly apply a sequence of blocks with input injection."""
+
+    def __init__(self, layers: List[HRMBlock]) -> None:
+        super().__init__()
+        self.layers = nn.ModuleList(layers)
+
+    def forward(self, hidden_states: torch.Tensor, input_injection: torch.Tensor, **kwargs) -> torch.Tensor:
+        hidden_states = hidden_states + input_injection
+        for layer in self.layers:
+            hidden_states = layer(hidden_states=hidden_states, **kwargs)
+        return hidden_states
+
+
+class TimeSeriesHRMCore(nn.Module):
+    """Hierarchical Reasoning core adapted for continuous time series."""
+
+    def __init__(
+        self,
+        d_model: int,
+        *,
+        num_heads: int = 8,
+        H_layers: int = 2,
+        L_layers: int = 2,
+        H_cycles: int = 1,
+        L_cycles: int = 4,
+        rope_theta: float = 10000.0,
+        max_position_embeddings: int = 2048,
+    ) -> None:
+        super().__init__()
+        self.H_cycles = H_cycles
+        self.L_cycles = L_cycles
+        self.rotary_emb = RotaryEmbedding(
+            dim=d_model // num_heads,
+            max_position_embeddings=max_position_embeddings,
+            base=rope_theta,
+        )
+        self.H_level = HRMReasoningModule([HRMBlock(d_model, num_heads) for _ in range(H_layers)])
+        self.L_level = HRMReasoningModule([HRMBlock(d_model, num_heads) for _ in range(L_layers)])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        z_H = torch.zeros_like(x)
+        z_L = torch.zeros_like(x)
+        cos_sin = self.rotary_emb()
+
+        for H_step in range(self.H_cycles):
+            for L_step in range(self.L_cycles):
+                if not (H_step == self.H_cycles - 1 and L_step == self.L_cycles - 1):
+                    z_L = self.L_level(z_L, z_H + x, cos_sin=cos_sin)
+            if H_step != self.H_cycles - 1:
+                z_H = self.H_level(z_H, z_L, cos_sin=cos_sin)
+
+        z_L = self.L_level(z_L, z_H + x, cos_sin=cos_sin)
+        z_H = self.H_level(z_H, z_L, cos_sin=cos_sin)
+        return z_H
+
+
+__all__ = ["TimeSeriesHRMCore"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 torch
+numpy
 adam-atan2
 einops
 tqdm

--- a/tests/test_lorenz_forecast.py
+++ b/tests/test_lorenz_forecast.py
@@ -1,0 +1,55 @@
+import numpy as np
+import torch
+from torch.utils.data import DataLoader
+
+from dataset.time_series_dataset import TimeSeriesWindows
+from models.ts_hierarchical_core import TimeSeriesHRMCore
+from models.ts_hrm_adapter import TimeSeriesHRM, ts_train_step
+
+
+def lorenz_series(T: int = 1000, dt: float = 0.01,
+                  sigma: float = 10.0, rho: float = 28.0,
+                  beta: float = 8/3) -> np.ndarray:
+    """Generate a Lorenz attractor time series of length ``T``.
+
+    Parameters
+    ----------
+    T: int
+        Number of timesteps to simulate.
+    dt: float
+        Integration step size.
+    sigma, rho, beta: float
+        Standard Lorenz system parameters.
+    """
+    xyz = np.zeros((T, 3), dtype=np.float32)
+    xyz[0] = np.array([1.0, 1.0, 1.0], dtype=np.float32)
+    for t in range(1, T):
+        x, y, z = xyz[t - 1]
+        x_dot = sigma * (y - x)
+        y_dot = x * (rho - z) - y
+        z_dot = x * y - beta * z
+        xyz[t] = xyz[t - 1] + dt * np.array([x_dot, y_dot, z_dot], dtype=np.float32)
+    return xyz
+
+
+def main() -> None:
+    series = lorenz_series()
+    dataset = TimeSeriesWindows(series, series, T_in=20, T_out=1)
+    loader = DataLoader(dataset, batch_size=32, shuffle=True)
+
+    d_in = series.shape[1]
+    d_model = 64
+    d_out = d_in
+    core = TimeSeriesHRMCore(d_model, num_heads=4, H_layers=2, L_layers=2)
+    model = TimeSeriesHRM(core, d_in=d_in, d_model=d_model, d_out=d_out)
+    opt = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+    batch = next(iter(loader))
+    loss = ts_train_step(model, batch)
+    loss.backward()
+    opt.step()
+    print(f"Loss after one training step: {loss.item():.2f}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement HRM-style core for continuous inputs
- run Lorenz forecast test using hierarchical core
- document new core in time-series adaptation guide

## Testing
- `pip install numpy` (failed: Could not find a version that satisfies the requirement numpy)
- `python tests/test_lorenz_forecast.py` (failed: ModuleNotFoundError: No module named 'numpy')

------
https://chatgpt.com/codex/tasks/task_e_689fba1524cc8333968ea07cc2e35d3a